### PR TITLE
Add param injection script to main branch

### DIFF
--- a/.github/workflows/autoinject_params.yaml
+++ b/.github/workflows/autoinject_params.yaml
@@ -1,0 +1,35 @@
+name: Auto-inject ADF parameters
+
+on:
+  push:
+    branches: ["workspace_publish"]
+
+env:
+  TEMPLATE_FILE: ./medalionsynapse12/TemplateForWorkspace.json
+  PARAM_FILE: ./medalionsynapse12/TemplateParametersForWorkspace.json
+  OUTPUT_FILE: ./injected_params/MedalionParams.json
+
+jobs:
+  inject-params:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Configure git client
+        run: |
+          git config user.name "GitHub Param Auto-Inject Action"
+          git config user.email "autoinjectaction@github.com"
+          mkdir -p injected_params
+      - name: Run parameters merge script
+        run: |
+          python3 ./scripts/autoinject_params.py \
+            --template-file $TEMPLATE_FILE \
+            --param-file $PARAM_FILE \
+            --output-file $OUTPUT_FILE
+      - name: Commit changes
+        run: |
+          git add $OUTPUT_FILE
+          git commit -m "Auto-inject parameters"
+          git push origin workspace_publish

--- a/scripts/autoinject_params.py
+++ b/scripts/autoinject_params.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import re
+import time
+
+
+def merge_parameters(template_file_path, param_file_path):
+    with open(param_file_path, "r") as file:
+        # The parameter file needs to be parsed in its entirety,
+        # so we aren't streaming it:
+        param_file = json.loads(file.read())
+    existing_params = param_file.get("parameters", {})
+    merged_params = {**existing_params}
+    pattern = re.compile(r"parameters\('(\w+)'\)")
+    with open(template_file_path, "r") as file:
+        # Since the ADF pipeline's template file can be quite big,
+        # it's better to avoid loading all of it into memory. Instead,
+        # trading for a slightly worse big-O:
+        for buff in file:
+            for param_name in pattern.findall(buff):
+                merged_params[param_name] = existing_params.get(param_name, {"value": "-"})
+    # Finally, write a timestamp parameter:
+    merged_params["AUTOINJECT_PARAMS_RAN_AT"] = {"value": str(int(time.time()))}
+    return {
+        **param_file,
+        "parameters": merged_params
+    }
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Add parameters to ARM template")
+    parser.add_argument("-t", "--template-file", type=str,
+                        help="Path to input ARM template file")
+    parser.add_argument("-p", "--param-file", type=str,
+                        help="Path to input ARM parameters file")
+    parser.add_argument("-o", "--output-file", type=str,
+                        help="Path to source ARM template file. If empty, write to stdout", default=None)
+    args = parser.parse_args()
+    res = merge_parameters(
+        template_file_path=args.template_file,
+        param_file_path=args.param_file
+    )
+    if args.output_file:
+        output_file = open(args.output_file, "w")
+        for line in json.dumps(res, indent="\t").split("\n"):
+            output_file.write(f"{line}\n")
+        output_file.close()
+    else:
+        print(json.dumps(res, indent=4))


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

Automates the detection and merging of additional parameters from the ADF template into the parameters file.  This could be particularly useful in cases where the parameters are required for spreading the pipeline in new environments, where you'd want to interpolate parameters in initialization SQL scripts.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

1. Check out the branch locally,
2. Make a local copy of the [`./medalionsynapse12`](https://github.com/MSFT-FTA-EMEA-ISV/sample-mdw-serverless/tree/workspace_publish/medalionsynapse12) directory from the `workspace_publish` branch (because they don't exist on other branches). Do not `git add` those files or commit them.
3. Run the following (Python 3 required):

  ```shell
  python scripts/autoinject_params.py \
    -t ./medalionsynapse12/TemplateForWorkspace.json \
    -p ./medalionsynapse12/MedalionParams.json \
    -o ./medalionsynapse12/MedalionParams.json
  ```

4. Finally, clean up by removing the `./medalionsynapse12` directory from this branch locally.

## What to Check

Verify that the new `MedalionParams.json` file contains new parameters detected in the template file.
